### PR TITLE
fix: 🐛 id for MongooseUsersRepository is not objectId

### DIFF
--- a/libs/users/infrastructure/mongoose/src/lib/mongoose-users.repository.spec.ts
+++ b/libs/users/infrastructure/mongoose/src/lib/mongoose-users.repository.spec.ts
@@ -27,13 +27,19 @@ describe('MongooseUsersRepository', () => {
   });
 
   it('should return a user when found', async () => {
-    const userDoc = { id: '1', name: 'John Doe' };
+    const mockUser = {
+      id: '507f1f77bcf86cd799439011',
+      name: 'Test User',
+    };
+
     jest.spyOn(userModel, 'findById').mockReturnValue({
-      exec: jest.fn().mockResolvedValue(userDoc),
+      exec: jest.fn().mockResolvedValue(mockUser),
     } as any);
 
-    const user = await repository.findById('1');
-    expect(user).toEqual(new User('1', 'John Doe'));
+    const user = await repository.findById(mockUser.id);
+    expect(user).toBeInstanceOf(User);
+    expect(user?.id).toBe(mockUser.id);
+    expect(user?.name).toBe(mockUser.name);
   });
 
   it('should return null when user is not found', async () => {
@@ -41,7 +47,7 @@ describe('MongooseUsersRepository', () => {
       exec: jest.fn().mockResolvedValue(null),
     } as any);
 
-    const user = await repository.findById('1');
+    const user = await repository.findById('507f1f77bcf86cd799439011');
     expect(user).toBeNull();
   });
 });

--- a/libs/users/infrastructure/mongoose/src/lib/mongoose-users.repository.ts
+++ b/libs/users/infrastructure/mongoose/src/lib/mongoose-users.repository.ts
@@ -1,22 +1,24 @@
 import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { User, UsersRepository } from '@users/domain';
-import { Model } from 'mongoose';
+import { Model, Types } from 'mongoose';
 
 import { UserDocument } from './user.schema';
 
-@Injectable() 
+@Injectable()
 export class MongooseUsersRepository implements UsersRepository {
   constructor(
     @InjectModel(UserDocument.name) private userModel: Model<UserDocument>,
   ) {}
 
   async findById(id: string): Promise<User | null> {
-    const userDoc = await this.userModel.findById(id).exec();
 
-    if (!userDoc) {
+    const _id = new Types.ObjectId(id);
+    const userDocument = await this.userModel.findById(_id).exec();
+
+    if (!userDocument) {
       return null;
     }
-    return new User(userDoc.id, userDoc.name);
+    return new User(userDocument.id, userDocument.name);
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved user retrieval logic by utilizing a more realistic MongoDB ObjectId format in the `findById` method.
	- Enhanced clarity in the code by renaming variables for better readability.

- **Tests**
	- Updated test cases to reflect new mock user data, ensuring accuracy in user ID and name validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->